### PR TITLE
Better mounts

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -230,9 +230,14 @@ func runSetupCommand(filePath string, containerPath string) {
 // where the new project should be written.
 //
 // An error is returned if it is encountered while prompting.
-func getProjectPath() (*projectSaveInfo, error) {
+func getProjectPath() (projectSaveInfo, error) {
 
-	var saveInfo *projectSaveInfo
+	// answers := struct {
+	// 	Name string `survey:"name"`
+	// 	Path string `survey:"path"`
+	// }{}
+
+	var answers projectSaveInfo
 
 	var qs = []*survey.Question{
 		{
@@ -256,17 +261,23 @@ func getProjectPath() (*projectSaveInfo, error) {
 				Help: "Provide a name for your project. The configuration directory will be saved\nunder the path:[project path]/[project name]",
 			},
 			Validate: func (val interface {}) error {
+				str, ok := val.(string)
+				if !ok {
+					return errors.New("could not use your path as a string")
+				}
+				if strings.Contains(str, string(os.PathSeparator)) {
+					return errors.New("your project name cannot contain path separators")
+				}
 				return nil
 			},
 		},
 	}
 
-	err := survey.Ask(qs, &saveInfo)
+	err := survey.Ask(qs, &answers)
 
 	if err != nil {
-		return nil, err
+		return answers, err
 	}
 
-	return  saveInfo, nil
+	return answers, nil
 }
-

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -232,11 +232,6 @@ func runSetupCommand(filePath string, containerPath string) {
 // An error is returned if it is encountered while prompting.
 func getProjectPath() (projectSaveInfo, error) {
 
-	// answers := struct {
-	// 	Name string `survey:"name"`
-	// 	Path string `survey:"path"`
-	// }{}
-
 	var answers projectSaveInfo
 
 	var qs = []*survey.Question{

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -76,6 +76,14 @@ func init() {
 	// setupCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }
 
+// projectSaveInfo is used ton store results from getProjectPath. The
+// user is prompted for a save path and a file name, which are stored as
+// "path" and "name", respectively.
+type projectSaveInfo struct {
+		path string
+		name string
+}
+
 // runSetupCommand uses Good Bot's Docker image to set up the project. It pulls
 // the image on each run. The container's output is copied to the shell's
 // stdout and the container is started interactively. This allows the user to

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -222,10 +222,7 @@ func runSetupCommand(filePath string, containerPath string) {
 // name. The path and the name are then joined to return the path towards
 // where the new project should be written.
 //
-// If an error is encountered while prompting or while trying to find an
-// absolute path, an empty string is returned along with the error.
-//
-// This function returns an absolute path on the host filesystem.
+// An error is returned if it is encountered while prompting.
 func getProjectPath() (*projectSaveInfo, error) {
 
 	var saveInfo *projectSaveInfo

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -250,6 +250,14 @@ func getProjectPath() (string, error) {
 		return "", err
 	}
 
-	return filepath.Join(projectSaveInfo.path, projectSaveInfo.name), nil
+	path := filepath.Join(projectSaveInfo.path, projectSaveInfo.name)
+
+	fullPath, err := filepath.Abs(path)
+
+	if err != nil {
+		return "", err
+	}
+
+	return  fullPath, nil
 }
 

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -112,6 +112,14 @@ func runSetupCommand(filePath string, containerPath string) {
 
 	containerScriptPath := containerPath + "/" + scriptName
 
+	writeRoot, err := os.Getwd()
+
+	if err != nil {
+		panic(err)
+	}
+
+	writeLoc := "/users-cwd"
+
 	resp, err := cli.ContainerCreate(ctx, &container.Config{
 
 		AttachStdin:  true,
@@ -127,6 +135,11 @@ func runSetupCommand(filePath string, containerPath string) {
 				Type:   mount.TypeBind,
 				Source: getDir(filePath),
 				Target: containerPath,
+			},
+			{
+				Type: mount.TypeBind,
+				Source: writeRoot,
+				Target: writeLoc,
 			},
 		},
 	}, nil, nil, "")

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -24,6 +24,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/docker/docker/api/types"
@@ -79,8 +80,8 @@ func init() {
 // user is prompted for a save path and a file name, which are stored as
 // "path" and "name", respectively.
 type projectSaveInfo struct {
-		path string
-		name string
+		Path string `survey:"path"`
+		Name string `survey:"name"`
 }
 
 // runSetupCommand uses Good Bot's Docker image to set up the project. It pulls
@@ -128,8 +129,8 @@ func runSetupCommand(filePath string, containerPath string) {
 		log.Fatal(err)
 	}
 
-	containerWritePath := filepath.Join(writeLoc, projectPath.name)
-	hostWritePath, err := filepath.Abs(projectPath.path)
+	containerWritePath := filepath.Join(writeLoc, projectPath.Name)
+	hostWritePath, err := filepath.Abs(projectPath.Path)
 
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -258,6 +258,7 @@ func getProjectPath() (*projectSaveInfo, error) {
 		return nil, err
 	}
 
+	// Changement 1
 	return  saveInfo, nil
 }
 

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -30,6 +30,7 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/spf13/cobra"
+	"github.com/AlecAivazis/survey/v2"
 )
 
 // setupCmd represents the setup command
@@ -127,7 +128,7 @@ func runSetupCommand(filePath string, containerPath string) {
 		AttachStderr: true,
 		Tty:          true,
 		OpenStdin:    true,
-		Cmd:          []string{"setup", containerScriptPath},
+		Cmd:          []string{"setup", "--project-path", , containerScriptPath},
 		Image:        "trickytroll/good-bot:latest",
 	}, &container.HostConfig{
 		Mounts: []mount.Mount{ // Mounting the location where the script is written.
@@ -205,4 +206,27 @@ func runSetupCommand(filePath string, containerPath string) {
 	}
 
 	stdcopy.StdCopy(os.Stdout, os.Stderr, out)
+}
+
+func getProjectPath(containerWriteLoc string) string {
+
+	var savePath string
+
+	q := &survey.Question{
+		Prompt: &survey.Input{
+			Message: "Where do you want to save your project?",
+			Help: "Provide an existing directory on your system. Good Bot will write your\nproject configuration in this directory."
+		},
+		// Making sure that the directory exists
+		Validate: func (val interface{}) error {
+			if str, ok := val.(string); !ok || !validatePath(str) {
+				return errors.New("the path provided does not seem to be valid")
+			}
+			return nil
+		},
+	}
+
+	survey.AskOne(q, &savePath)
+
+	return savePath
 }

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -218,12 +218,17 @@ func runSetupCommand(filePath string, containerPath string) {
 	stdcopy.StdCopy(os.Stdout, os.Stderr, out)
 }
 
-func getProjectPath() (string, error) {
+// getProjectPath prompts the user for a project save path and a project
+// name. The path and the name are then joined to return the path towards
+// where the new project should be written.
+//
+// If an error is encountered while prompting or while trying to find an
+// absolute path, an empty string is returned along with the error.
+//
+// This function returns an absolute path on the host filesystem.
+func getProjectPath() (*projectSaveInfo, error) {
 
-	projectSaveInfo := struct {
-		path string
-		name string
-	}{}
+	var saveInfo *projectSaveInfo
 
 	var qs = []*survey.Question{
 		{
@@ -252,14 +257,12 @@ func getProjectPath() (string, error) {
 		},
 	}
 
-	err := survey.Ask(qs, &projectSaveInfo)
+	err := survey.Ask(qs, &saveInfo)
 
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	path := filepath.Join(projectSaveInfo.path, projectSaveInfo.name)
-
-	return  path, nil
+	return  saveInfo, nil
 }
 

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -23,16 +23,14 @@ import (
 	"io"
 	"log"
 	"os"
-	"path/filepath"
-	"strings"
 
-	"github.com/AlecAivazis/survey/v2"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/spf13/cobra"
+	"github.com/AlecAivazis/survey/v2"
 )
 
 // setupCmd represents the setup command
@@ -130,7 +128,7 @@ func runSetupCommand(filePath string, containerPath string) {
 		AttachStderr: true,
 		Tty:          true,
 		OpenStdin:    true,
-		Cmd:          []string{"setup", "--project-path", containerScriptPath},
+		Cmd:          []string{"setup", "--project-path", , containerScriptPath},
 		Image:        "trickytroll/good-bot:latest",
 	}, &container.HostConfig{
 		Mounts: []mount.Mount{ // Mounting the location where the script is written.
@@ -210,46 +208,25 @@ func runSetupCommand(filePath string, containerPath string) {
 	stdcopy.StdCopy(os.Stdout, os.Stderr, out)
 }
 
-func getProjectPath() (string, error) {
+func getProjectPath(containerWriteLoc string) string {
 
-	projectSaveInfo := struct {
-		path string
-		name string
-	}{}
+	var savePath string
 
-	var qs = []*survey.Question{
-		{
-			Name: "path",
-			Prompt: &survey.Input{
-				Message: "Where do you want to save your project?",
-				Help: "Provide an existing directory on your system. Good Bot will write your\nproject configuration in this directory.",
-			},
-			// Making sure that the directory exists
-			Validate: func (val interface{}) error {
-				if str, ok := val.(string); !ok || !validatePath(str) {
-					return errors.New("the path provided does not seem to be valid")
-				}
-				return nil
-			},
+	q := &survey.Question{
+		Prompt: &survey.Input{
+			Message: "Where do you want to save your project?",
+			Help: "Provide an existing directory on your system. Good Bot will write your\nproject configuration in this directory."
 		},
-		{
-			Name: "name",
-			Prompt: &survey.Input{
-				Message: "How do you want to name your project?",
-				Help: "Provide a name for your project. The configuration directory will be saved\nunder the path:[project path]/[project name]",
-			},
-			Validate: func (val interface {}) error {
-				return nil
-			},
+		// Making sure that the directory exists
+		Validate: func (val interface{}) error {
+			if str, ok := val.(string); !ok || !validatePath(str) {
+				return errors.New("the path provided does not seem to be valid")
+			}
+			return nil
 		},
 	}
 
-	err := survey.Ask(qs, &projectSaveInfo)
+	survey.AskOne(q, &savePath)
 
-	if err != nil {
-		return "", err
-	}
-
-	return filepath.Join(projectSaveInfo.path, projectSaveInfo.name), nil
+	return savePath
 }
-

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -252,12 +252,6 @@ func getProjectPath() (string, error) {
 
 	path := filepath.Join(projectSaveInfo.path, projectSaveInfo.name)
 
-	fullPath, err := filepath.Abs(path)
-
-	if err != nil {
-		return "", err
-	}
-
-	return  fullPath, nil
+	return  path, nil
 }
 

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -23,8 +23,6 @@ import (
 	"io"
 	"log"
 	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/docker/docker/api/types"

--- a/cmd/setup_test.go
+++ b/cmd/setup_test.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"testing"
+	"time"
+	"log"
+	expect "github.com/Netflix/go-expect"
+)
+
+func TestGetProjectPath(t *testing.T) {
+
+	c, err := expect.NewConsole(expect.WithStdout(os.Stdout))
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer c.Close()
+
+
+	go func() {
+		c.ExpectEOF()
+	}()
+
+	err = cmd.Start()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	time.Sleep(time.Second)
+	c.Send("iHello world\x1b")
+	time.Sleep(time.Second)
+	c.Send("dd")
+	time.Sleep(time.Second)
+	c.SendLine(":q!")
+
+	err = cmd.Wait()
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.2.15 // indirect
+	github.com/Netflix/go-expect v0.0.0-20210722184520-ef0bf57d82b3 // indirect
 	github.com/containerd/containerd v1.5.3 // indirect
 	github.com/docker/docker v20.10.7+incompatible
 	github.com/docker/go-connections v0.4.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/TrickyTroll/good-bot-cli
 go 1.16
 
 require (
+	github.com/AlecAivazis/survey/v2 v2.2.15 // indirect
 	github.com/containerd/containerd v1.5.3 // indirect
 	github.com/docker/docker v20.10.7+incompatible
 	github.com/docker/go-connections v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohl
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+github.com/AlecAivazis/survey/v2 v2.2.15 h1:6UNMnk+YGegYFiPfdTOyZDIN+m08x2nGnqOn15BWcEQ=
+github.com/AlecAivazis/survey/v2 v2.2.15/go.mod h1:TH2kPCDU3Kqq7pLbnCWwZXDBjnhZtmsCle5EiYDJ2fg=
 github.com/Azure/azure-sdk-for-go v16.2.1+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7OZ575w+acHgRric5iCyQh+xv+KJ4HB8=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
@@ -75,6 +77,7 @@ github.com/Microsoft/hcsshim v0.8.18/go.mod h1:+w2gRZ5ReXQhFOrvSQeNfhrYB/dg3oDwT
 github.com/Microsoft/hcsshim/test v0.0.0-20201218223536-d3e5debf77da/go.mod h1:5hlzMzRKMLyo42nCZ9oml8AdTlq/0cvIaBv6tK1RehU=
 github.com/Microsoft/hcsshim/test v0.0.0-20210227013316-43a75bb4edd3/go.mod h1:mw7qgWloBUl75W/gVH3cQszUg1+gUITj7D6NY7ywVnY=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
+github.com/Netflix/go-expect v0.0.0-20180615182759-c93bf25de8e8/go.mod h1:oX5x61PbNXchhh0oikYAH+4Pcfw5LKv21+Jnpr6r6Pc=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
@@ -422,6 +425,7 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
+github.com/hinshun/vt10x v0.0.0-20180616224451-1954e6464174/go.mod h1:DqJ97dSdRW1W22yXSB90986pcOyQ7r45iio1KN2ez1A=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -446,6 +450,8 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a h1:FaWFmfWdAUKbSCtOU2QjDaorUexogfaMgbipgYATUMU=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
@@ -462,6 +468,7 @@ github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/pty v1.1.4/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
@@ -478,13 +485,19 @@ github.com/manifoldco/promptui v0.8.0/go.mod h1:n4zTdgP0vr0S3w7/O/g98U+e0gwLScEX
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
 github.com/mattn/go-colorable v0.0.9 h1:UVL0vNpWh04HeJXV0KLcaT7r06gOH2l4OW6ddYRUIY4=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
+github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
+github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.4 h1:bnP0vzxcAdeI1zdubAl5PjU6zsERjGZb7raWodagDYs=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=
+github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-shellwords v1.0.3/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=
+github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
@@ -658,6 +671,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v0.0.0-20180303142811-b89eecf5ca5d/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -727,6 +741,7 @@ golang.org/x/crypto v0.0.0-20181009213950-7c1a557ab941/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20190530122614-20be4c3c3ed5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -852,6 +867,7 @@ golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -923,6 +939,8 @@ golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007 h1:gG67DSER+11cZvqIMb8S8bt0vZtiN6xWYARwirrOSfE=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/term v0.0.0-20210503060354-a79de5458b56 h1:b8jxX3zqjpqb2LklXPzKSGJhzyxCOZSz8ncv8Nv+y7w=
+golang.org/x/term v0.0.0-20210503060354-a79de5458b56/go.mod h1:tfny5GFUkzUvx4ps4ajbZsCe5lw1metzhBm9T3x7oIY=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/Microsoft/hcsshim/test v0.0.0-20201218223536-d3e5debf77da/go.mod h1:5
 github.com/Microsoft/hcsshim/test v0.0.0-20210227013316-43a75bb4edd3/go.mod h1:mw7qgWloBUl75W/gVH3cQszUg1+gUITj7D6NY7ywVnY=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/Netflix/go-expect v0.0.0-20180615182759-c93bf25de8e8/go.mod h1:oX5x61PbNXchhh0oikYAH+4Pcfw5LKv21+Jnpr6r6Pc=
+github.com/Netflix/go-expect v0.0.0-20210722184520-ef0bf57d82b3 h1:DM0Olh3jQEm4gVPLF0mI49+fm1+M1fXDtumX/fN/G4A=
+github.com/Netflix/go-expect v0.0.0-20210722184520-ef0bf57d82b3/go.mod h1:68ORG0HSEWDuH5Eh73AFbYWZ1zT4Y+b0vhOa+vZRUdI=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
@@ -469,6 +471,7 @@ github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.4/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/pty v1.1.5 h1:hyz3dwM5QLc1Rfoz4FuWJQG5BN7tc6K1MndAUnGpQr4=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=


### PR DESCRIPTION
## New

* `getProjectPath` function to prompt the user on a project name and a project path.
* Using the results from `getProjectPath` for a new mount in the `setup` command.
* Users can now choose where to save their project. Closes #14
* `projectSaveInfo` type to store the results from `getProjectPath`'s prompt.

## In progress

* Adding tests for interactive commands using `go-expect`