### PR TITLE
New way to update

### DIFF
--- a/cmd/record.go
+++ b/cmd/record.go
@@ -157,11 +157,14 @@ func runRecordCommand(hostPath string, ttsFile string, envVars []string, setting
 		panic(err)
 	}
 
-	reader, err := cli.ImagePull(ctx, "trickytroll/good-bot:latest", types.ImagePullOptions{})
-	if err != nil {
-		panic(err)
+
+	if !imageExists("trickytroll/good-bot:latest", ctx, cli) {
+		reader, err := cli.ImagePull(ctx, "trickytroll/good-bot:latest", types.ImagePullOptions{})
+		if err != nil {
+			panic(err)
+		}
+		io.Copy(os.Stdout, reader)
 	}
-	io.Copy(os.Stdout, reader)
 
 	stats, err := os.Stat(hostPath)
 	if err != nil {

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -117,11 +117,13 @@ func renderAllRecordings(projectPath string) {
 		panic(err)
 	}
 
-	reader, err := cli.ImagePull(ctx, "asciinema/asciicast2gif", types.ImagePullOptions{})
-	if err != nil { // If no reader the rest of the program won't work.
-		panic(err)
+	if !imageExists("asciinema/asciicast2gif", ctx, cli) {
+		reader, err := cli.ImagePull(ctx, "asciinema/asciicast2gif", types.ImagePullOptions{})
+		if err != nil { // If no reader the rest of the program won't work.
+			panic(err)
+		}
+		io.Copy(os.Stdout, reader) // Print container info to stdout.
 	}
-	io.Copy(os.Stdout, reader) // Print container info to stdout.
 
 	toRecord := getRecsPaths(projectPath)
 	for _, item := range toRecord {
@@ -275,11 +277,13 @@ func renderVideo(projectPath string) string {
 		panic(err)
 	}
 
-	reader, err := cli.ImagePull(ctx, "trickytroll/good-bot:latest", types.ImagePullOptions{})
-	if err != nil {
-		panic(err)
+	if !imageExists("trickytroll/good-bot:latest", ctx, cli) {
+		reader, err := cli.ImagePull(ctx, "trickytroll/good-bot:latest", types.ImagePullOptions{})
+		if err != nil {
+			panic(err)
+		}
+		io.Copy(os.Stdout, reader)
 	}
-	io.Copy(os.Stdout, reader)
 
 	stats, err := os.Stat(projectPath)
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -87,6 +87,9 @@ func initConfig() {
 	viper.AutomaticEnv() // read in environment variables that match
 }
 
+// imageExists uses the Docker SDK to check if the provided image name
+// exists on the host. It uses the ImageList function provided by the
+// SDK's client type.
 func imageExists(imageName string, ctx context.Context, cli *client.Client) bool {
 
 	images, err := cli.ImageList(ctx, types.ImageListOptions{})

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,7 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -25,6 +26,8 @@ import (
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -82,6 +85,22 @@ func initConfig() {
 	}
 
 	viper.AutomaticEnv() // read in environment variables that match
+}
+
+func imageExists(imageName string, ctx context.Context, cli *client.Client) bool {
+
+	images, err := cli.ImageList(ctx, types.ImageListOptions{})
+	if err != nil {
+		panic(err)
+	}
+
+	for _, image := range images{
+		if strings.Contains(image.ID, imageName){
+			return true
+		}
+	}
+
+	return false
 }
 
 // validatePath checks whether or not a path exists. The check is done using

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -98,11 +98,12 @@ func imageExists(imageName string, ctx context.Context, cli *client.Client) bool
 	}
 
 	for _, image := range images{
-		if strings.Contains(image.ID, imageName){
-			return true
+		for _, tag := range image.RepoTags{
+				if strings.Contains(tag, imageName) {
+				return true
+			}
 		}
 	}
-
 	return false
 }
 

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -107,11 +107,13 @@ func runSetupCommand(filePath string, containerPath string) {
 		panic(err)
 	}
 
-	reader, err := cli.ImagePull(ctx, "trickytroll/good-bot:latest", types.ImagePullOptions{})
-	if err != nil { // If no reader the rest of the program won't work.
-		panic(err)
+	if !imageExists("trickytroll/good-bot", ctx, cli) {
+		reader, err := cli.ImagePull(ctx, "trickytroll/good-bot:latest", types.ImagePullOptions{})
+		if err != nil { // If no reader the rest of the program won't work.
+			panic(err)
+		}
+		io.Copy(os.Stdout, reader) // Print container info to stdout.
 	}
-	io.Copy(os.Stdout, reader) // Print container info to stdout.
 
 	// Script and infos are written in containerPath. The directory
 	// where the script resides on the host will be mounted to containerPath.

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,0 +1,78 @@
+/*
+Copyright © 2021 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"context"
+	"io"
+	"os"
+	"github.com/docker/docker/api/types"
+	"github.com/spf13/cobra"
+	"github.com/docker/docker/client"
+)
+
+// updateCmd represents the update command
+var updateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update the app by pulling the latest docker image.",
+	Long: `Updates the Good-Bot and the Asciicast2gif docker images.
+
+It uses the equivalent of the docker pull command to update your
+application. To see what will change, please refer to Good-Bot's
+changelog.
+
+It updates every image if no argument is provided.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) > 0 {
+			update(args)
+		} else {
+			defaultArgs := []string{"trickytroll/good-bot:latest", "asciinema/asciicast2gif"}
+			update(defaultArgs)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(updateCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// updateCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// updateCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}
+
+func update(toUpdate []string) {
+
+	for _, imageName := range toUpdate {
+
+		ctx := context.Background()
+		cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+		if err != nil { // cli fails nothing else will work. Should panic.
+			panic(err)
+		}
+
+		reader, err := cli.ImagePull(ctx, imageName, types.ImagePullOptions{})
+		if err != nil { // If no reader the rest of the program won't work.
+			panic(err)
+		}
+		io.Copy(os.Stdout, reader) // Print container info to stdout.
+	}
+}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -17,11 +17,13 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
+
 	"github.com/docker/docker/api/types"
-	"github.com/spf13/cobra"
 	"github.com/docker/docker/client"
+	"github.com/spf13/cobra"
 )
 
 // updateCmd represents the update command
@@ -36,6 +38,7 @@ changelog.
 
 It updates every image if no argument is provided.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Updating images...")
 		if len(args) > 0 {
 			update(args)
 		} else {
@@ -63,6 +66,7 @@ func update(toUpdate []string) {
 
 	for _, imageName := range toUpdate {
 
+		fmt.Printf("Updating %s\n", imageName)
 		ctx := context.Background()
 		cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 		if err != nil { // cli fails nothing else will work. Should panic.


### PR DESCRIPTION
The `docker pull` command is no longer being used on each run. Instead, the image is only pulled if it has not yet been downloaded on the host. Closes #21 

To update their images, users should now rely on the new `update` command.

## New

* `imageExists` function to check if an image has already been downloaded.
* `update` command to the CLI.

## Change

* Images are no longer pulled on each run.